### PR TITLE
Stop searching config if we reach root directory

### DIFF
--- a/tasks/csscomb.js
+++ b/tasks/csscomb.js
@@ -20,7 +20,7 @@ module.exports = function (grunt) {
         function getConfigPath(configPath) {
             var dirname, parentDirname;
 
-            configPath = configPath || process.cwd() + '/.csscomb.json';
+            configPath = configPath || path.join(process.cwd(), '.csscomb.json');
 
             // If we've finally found a config, return its path:
             if (grunt.file.exists(configPath)) {
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
 
             // If there is no config in this directory, go one level up and look for
             // a config there:
-            configPath = parentDirname + '/.csscomb.json';
+            configPath = path.join(parentDirname, '.csscomb.json');
             return getConfigPath(configPath);
         }
 


### PR DESCRIPTION
Fix #19.

Since project can be located not under `HOME`, we should stop searching config if we reach root.
There appears to be no good way to get root path in Windows, that's why assume that if current dir has no parent dir, we're in root.

![giphy](https://f.cloud.github.com/assets/872004/1817124/f84d9ace-6f74-11e3-8f9f-42918e8a0020.gif)
