### PR TITLE
Feature src only

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
 
         // Before generating any new files, remove any previously-created files.
         clean: {
-            tests: ['test/fixtures/tmp_*.css','test/fixtures/dest/*.resorted.css'],
+            tests: ['test/fixtures/tmp_*.css','test/fixtures/dest/*.resorted.css','test/fixtures/src/*.resorted.css'],
         },
 
         // Configuration to be run (and then tested).
@@ -53,6 +53,10 @@ module.exports = function (grunt) {
                 cwd: 'test/fixtures/dest/',
                 src: ['*.css', '!*.resorted.css'],
                 dest: 'test/fixtures/dest/',
+                ext: '.resorted.css'
+            },
+            src_only: {
+                src: ['test/fixtures/src/*.css'],
                 ext: '.resorted.css'
             }
         },

--- a/tasks/csscomb.js
+++ b/tasks/csscomb.js
@@ -72,9 +72,10 @@ module.exports = function (grunt) {
                 }
             }).forEach(function (src) {
                 var dest = f.dest;
+                var syntax = src.split('.').pop();
 
                 if (!dest) {
-                    dest = grunt.file.expandMapping(src, '', { ext: f.ext || ''})[0].dest;
+                    dest = grunt.file.expandMapping(src, '', { ext: f.ext || '.' + syntax})[0].dest;
                 }
 
                 // Get CSS from a source file:
@@ -83,6 +84,7 @@ module.exports = function (grunt) {
 
                 // Comb it:
                 grunt.log.ok('Sorting file "' + src + '"...');
+
                 var syntax = src.split('.').pop();
 
                 try {

--- a/tasks/csscomb.js
+++ b/tasks/csscomb.js
@@ -71,6 +71,11 @@ module.exports = function (grunt) {
                     return true;
                 }
             }).forEach(function (src) {
+                var dest = f.dest;
+
+                if (!dest) {
+                    dest = grunt.file.expandMapping(src, '', { ext: f.ext || ''})[0].dest;
+                }
 
                 // Get CSS from a source file:
                 var css = grunt.file.read(src);
@@ -79,9 +84,10 @@ module.exports = function (grunt) {
                 // Comb it:
                 grunt.log.ok('Sorting file "' + src + '"...');
                 var syntax = src.split('.').pop();
+
                 try {
                     combed = comb.processString(css, { syntax: syntax });
-                    grunt.file.write(f.dest, combed);
+                    grunt.file.write(dest, combed);
                 } catch(e) {
                     grunt.log.error(e);
                 }

--- a/test/csscomb_test.js
+++ b/test/csscomb_test.js
@@ -8,7 +8,7 @@ exports.csscomb = {
 
         var actual = grunt.file.read('test/fixtures/tmp_resort.css');
         var expected = grunt.file.read('test/expected/resort.css');
-        test.equal(actual, expected, 'sholud be sorted.');
+        test.equal(actual, expected, 'should be sorted.');
 
         test.done();
     },
@@ -17,7 +17,7 @@ exports.csscomb = {
 
         var actual = grunt.file.read('test/fixtures/tmp_customsort.css');
         var expected = grunt.file.read('test/expected/customsort.css');
-        test.equal(actual, expected, 'sholud be custom sorted.');
+        test.equal(actual, expected, 'should be custom sorted.');
 
         test.done();
     },
@@ -26,11 +26,11 @@ exports.csscomb = {
 
         var actual = grunt.file.read('test/fixtures/tmp_multi1.css');
         var expected = grunt.file.read('test/expected/multi1.css');
-        test.equal(actual, expected, 'sholud be sorted.');
+        test.equal(actual, expected, 'should be sorted.');
 
         var actual2 = grunt.file.read('test/fixtures/tmp_multi2.css');
         var expected2 = grunt.file.read('test/expected/multi2.css');
-        test.equal(actual2, expected2, 'sholud be sorted.');
+        test.equal(actual2, expected2, 'should be sorted.');
 
         test.done();
     },
@@ -39,11 +39,24 @@ exports.csscomb = {
 
         var actual = grunt.file.read('test/fixtures/dest/multi1.resorted.css');
         var expected = grunt.file.read('test/expected/multi1.css');
-        test.equal(actual, expected, 'sholud be sorted.');
+        test.equal(actual, expected, 'should be sorted.');
 
         var actual2 = grunt.file.read('test/fixtures/dest/multi2.resorted.css');
         var expected2 = grunt.file.read('test/expected/multi2.css');
-        test.equal(actual2, expected2, 'sholud be sorted.');
+        test.equal(actual2, expected2, 'should be sorted.');
+
+        test.done();
+    },
+    src_only: function (test) {
+        test.expect(2);
+
+        var actual = grunt.file.read('test/fixtures/src/multi1.resorted.css');
+        var expected = grunt.file.read('test/expected/multi1.css');
+        test.equal(actual, expected, 'should be sorted.');
+
+        var actual2 = grunt.file.read('test/fixtures/src/multi2.resorted.css');
+        var expected2 = grunt.file.read('test/expected/multi2.css');
+        test.equal(actual2, expected2, 'should be sorted.');
 
         test.done();
     }

--- a/test/fixtures/src/multi1.css
+++ b/test/fixtures/src/multi1.css
@@ -1,0 +1,13 @@
+.multi1 {
+    z-index: 100;
+    display: block;
+    visibility: hidden;
+    max-height: 44px;
+    width: 100px;
+    height: 100px;
+    border-color: 1px #000 solid;
+    background-color: red;
+    vertical-align: 5px;
+    text-align: center;
+    font-weight: bold;
+}

--- a/test/fixtures/src/multi1.resorted.css
+++ b/test/fixtures/src/multi1.resorted.css
@@ -1,0 +1,19 @@
+.multi1
+{
+    font-weight: bold;
+
+    z-index: 100;
+
+    display: block;
+    visibility: hidden;
+
+    width: 100px;
+    height: 100px;
+    max-height: 44px;
+
+    text-align: center;
+    vertical-align: 5px;
+
+    border-color: 1px #000 solid;
+    background-color: red;
+}

--- a/test/fixtures/src/multi2.css
+++ b/test/fixtures/src/multi2.css
@@ -1,0 +1,13 @@
+.multi2 {
+	position: absolute;
+	top: 10px;
+	left: 10px;
+	z-index: 10;
+	display: table;
+	float: left;
+	margin: 10px;
+	padding: 10px;
+	width: 10px;
+	height: 10px;
+	border: 1px #fff solid;
+}

--- a/test/fixtures/src/multi2.resorted.css
+++ b/test/fixtures/src/multi2.resorted.css
@@ -1,0 +1,17 @@
+.multi2
+{
+    position: absolute;
+    z-index: 10;
+    top: 10px;
+    left: 10px;
+
+    display: table;
+    float: left;
+
+    width: 10px;
+    height: 10px;
+    margin: 10px;
+    padding: 10px;
+
+    border: 1px #fff solid;
+}


### PR DESCRIPTION
Ability to only add src files

```
src_only: {
    src: ['test/fixtures/src/*.css'],
    ext: '.resorted.css'
},
src_only_short: ['test/fixtures/src/*.css']
```
